### PR TITLE
Add TypeScript CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
       - run: npm install
       - run: npm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm install
+      - run: npm run typecheck

--- a/electron/renderer/renderer.ts
+++ b/electron/renderer/renderer.ts
@@ -1,3 +1,5 @@
+export {};
+
 declare global {
   interface Window {
     opencue: {

--- a/server/router/provider.ts
+++ b/server/router/provider.ts
@@ -1,4 +1,4 @@
-import fetch from "node-fetch";
+import fetch, { type Response } from "node-fetch";
 
 const toText = async (r: Response) => {
   const t = await r.text();


### PR DESCRIPTION
Adds Node 22 typecheck workflow and fixes existing renderer/module and node-fetch Response typing errors so tsc passes. Local npm run typecheck passes. Closes warren-376c.